### PR TITLE
Add gemini-cli documentation page

### DIFF
--- a/docs/reference/clients/gemini-cli.md
+++ b/docs/reference/clients/gemini-cli.md
@@ -1,0 +1,13 @@
+---
+title: Gemini CLI
+url: https://github.com/google-gemini/gemini-cli
+logo: https://www.gstatic.com/ai/web/favicons/favicon-32x32.png
+models: Gemini 2.5 Pro, Vertex AI models
+ui_type: CLI
+ease_of_use_for_non_technical: 4
+github: https://github.com/google-gemini/gemini-cli
+---
+
+Gemini CLI is Google's open-source command-line AI workflow tool that brings the power of Gemini directly into your terminal. It connects to your tools, understands your code, and accelerates your workflows using a "reason and act (ReAct) loop" with built-in tools to complete complex tasks.
+
+Key features include querying and editing large codebases within Gemini's 1M token context window, generating new applications from PDFs or sketches using multimodal capabilities, and automating operational tasks like querying pull requests or handling complex rebases. The tool supports local and remote Model Context Protocol (MCP) servers and includes built-in tools for grep, terminal operations, file read/write, web search, and web fetch.


### PR DESCRIPTION
Adds comprehensive documentation for Google's Gemini CLI following the same format as the goose page.

Includes:
- YAML frontmatter with all required fields
- Description based on official Google documentation
- Key features and capabilities
- Supported models and UI information

Fixes #18

Generated with [Claude Code](https://claude.ai/code)