### PR TITLE
Add gemini-cli documentation page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
      - Clients:
         - Claude Desktop: reference/clients/claude-desktop.md
         - Claude Code: reference/clients/claude-code.md
+        - Gemini CLI: reference/clients/gemini-cli.md
         - Goose: reference/clients/goose.md
   - FAQ: faq.md
   - Glossary: glossary.md


### PR DESCRIPTION
Adds comprehensive documentation for Google's Gemini CLI following the same format as the goose page and adds it to mkdocs.yml navigation.

Includes:
- YAML frontmatter with all required fields
- Description based on official Google documentation
- Key features and capabilities
- Supported models and UI information
- Navigation entry in mkdocs.yml

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)