### PR TITLE
Fix mkdocs configuration errors

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,9 @@
+# FAQ
+
+## What is this project?
+
+This site collects guidance for using AI to assist with curation workflows.
+
+## How can I contribute?
+
+Contributions are welcome via pull requests on the project's GitHub repository.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,7 +2,15 @@
 
 ## AI Agent
 
-An agent is a program that allows AI models to call [tools](#tool) to achieve some objective. 
+An agent is a program that allows AI models to call [tools](#tool) to achieve some objective.
+
+## Tool
+
+A software capability or utility that an AI agent can invoke to perform a specific task, such as reading files, running code, or querying a service.
+
+## Agentic Coding Tool
+
+An environment or application that enables an AI system to modify code or other files using natural language commands.
 
 ## CBORG
 

--- a/docs/how-tos/instruct-github-agent.md
+++ b/docs/how-tos/instruct-github-agent.md
@@ -1,6 +1,6 @@
 # AI Instructors Guide: GitHub Agents
 
-This is a guide for instructing the [AI agent](../glossary.md#ai-agent) that lives in GitHub repo. This assumes your AI controller has [set up [GitHub actions](../glossary.md#github-actions)](set-up-github-actions) in your repo.
+This is a guide for instructing the [AI agent](../glossary.md#ai-agent) that lives in GitHub repo. This assumes your AI controller has [set up [GitHub actions](../glossary.md#github-actions)](set-up-github-actions.md) in your repo.
 
 ## How it works
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,1 @@
+/* Additional customization styles */


### PR DESCRIPTION
## Summary
- add glossary entries for tool and agentic coding tool
- fix relative link in GitHub agent how-to
- add missing FAQ page and stylesheet for mkdocs

## Testing
- `mkdocs build`


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6898cf2c3bd8832e9e0e276d232e2840)