### PR TITLE
[codex] Support CBORG Claude action setup

### DIFF
--- a/.github/actions/claude-code-action/action.yml
+++ b/.github/actions/claude-code-action/action.yml
@@ -8,6 +8,9 @@ inputs:
   anthropic_api_key:
     description: "Anthropic API key"
     required: true
+  cborg_api_key:
+    description: "CBORG API key"
+    required: true
   prompt:
     description: "The prompt to send to Claude Code"
     required: false
@@ -32,10 +35,18 @@ inputs:
     description: "Whether to install the GitHub MCP server"
     required: false
     default: "false"
+  install_artl_mcp:
+    description: "Whether to install the ARTL MCP server"
+    required: false
+    default: "false"
+
 
 runs:
   using: "composite"
   steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Install Claude Code
       shell: bash
       run: npm install -g @anthropic-ai/claude-code
@@ -55,8 +66,19 @@ runs:
             "ghcr.io/github/github-mcp-server:sha-ff3036d"
           ],
           "env": {
-            "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ inputs.GITHUB_TOKEN }}"
+            "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ inputs.github_token }}"
           }
+        }'
+
+    - name: Install ARTL MCP Server
+      if: inputs.install_artl_mcp == 'true'
+      shell: bash
+      run: |
+        claude mcp add-json artl '{
+          "command": "uvx",
+          "args": [
+            "artl-mcp"
+          ]
         }'
 
     - name: Prepare Prompt File
@@ -131,6 +153,11 @@ runs:
 
           echo "Complete output saved to output.json, final response saved to ${{ inputs.output_file }}"
         fi
+
       env:
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        # CBORG uses ANTHROPIC_AUTH_TOKEN; Claude Code still expects ANTHROPIC_API_KEY.
+        ANTHROPIC_API_KEY: "."
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.cborg_api_key }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        ANTHROPIC_BASE_URL: "https://api.cborg.lbl.gov"
+        DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1"

--- a/.github/actions/claude-issue-triage-action/action.yml
+++ b/.github/actions/claude-issue-triage-action/action.yml
@@ -9,6 +9,9 @@ inputs:
   anthropic_api_key:
     description: "Anthropic API key"
     required: true
+  cborg_api_key:
+    description: "CBORG API key"
+    required: true
   github_token:
     description: "GitHub token with repo and issues permissions"
     required: true
@@ -84,4 +87,5 @@ runs:
         install_github_mcp: "true"
         timeout_minutes: ${{ inputs.timeout_minutes }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        cborg_api_key: ${{ inputs.cborg_api_key }}
         github_token: ${{ inputs.github_token }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,8 @@
+# Claude Code GitHub action
+# ---
+# This github action is from the copier template in https://github.com/ai4curation/github-ai-integrations, donated by the Monarch Initiative
+# For more documentation, see https://ai4curation.github.io/aidocs/how-tos/set-up-github-actions/
+# Author: Chris Mungall (@cmungall)
 name: Claude Code
 
 on:
@@ -18,6 +23,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- add `cborg_api_key` plumbing to the reusable Claude Code composite action and issue triage wrapper
- configure Claude Code to use the CBORG Anthropic-compatible endpoint
- add optional ARTL MCP installation through `uvx`
- add provenance comments and a timeout to the main Claude mention workflow

## Validation

- `git diff --cached --check`
- parsed all GitHub workflow/action YAML files with `uv run python` in a clean worktree