### PR TITLE
[codex] Add shared AI agent setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.goosehints
+++ b/.goosehints
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md for aidocs
+
+This file provides guidance to AI coding agents working in this repository.
+
+## Project overview
+
+`aidocs` is a documentation repository for AI4Curators. It provides practical
+guides for curators and maintainers of knowledge bases who want to integrate AI
+agents into their workflows.
+
+The project focuses on immediately usable guidance rather than theoretical
+discussion. Most content should help practitioners set up or improve real
+GitHub-based curation workflows.
+
+## Repository structure
+
+```text
+aidocs/
+├── docs/                     # MkDocs documentation source
+│   ├── how-tos/              # Practical task-oriented guides
+│   ├── tutorials/            # Learning-oriented walkthroughs
+│   ├── reference/            # Technical reference material
+│   │   └── clients/          # AI client documentation
+│   └── overrides/            # MkDocs theme customizations
+├── src/aidocs/               # Python package source
+├── ai.just                   # AI setup helper recipes
+├── mkdocs.yml                # MkDocs configuration
+└── pyproject.toml            # Python project configuration
+```
+
+## Repo management
+
+This repo uses `uv` for managing dependencies. Never use commands like `pip` to
+add or manage dependencies.
+
+Use `uv run` to run Python tools, unless a `justfile`, `*.just`, or `makefile`
+target is the established entry point for the task.
+
+MkDocs is used for documentation. Use `uv run mkdocs build` to check the site.
+Use `uv run mkdocs build --strict` when making documentation changes that should
+not introduce warnings.
+
+## Documentation standards
+
+- Prefer practical, immediately actionable content.
+- Provide step-by-step guides over abstract discussion when writing how-tos.
+- Include real-world examples and curation use cases.
+- Keep terminology consistent with existing pages in `docs/glossary.md`.
+- Preserve the existing MkDocs Material style and navigation patterns.
+
+## Content categories
+
+- `docs/how-tos/`: task-oriented implementation guides.
+- `docs/tutorials/`: comprehensive walkthroughs for learning.
+- `docs/reference/`: technical reference material and tool descriptions.
+- `docs/glossary.md`: domain-specific terminology.
+
+## Target audience
+
+The primary audience is curators and maintainers of knowledge bases and
+ontologies. The secondary audience is developers integrating AI into existing
+curation workflows.
+
+## Contributing guidance
+
+- Prioritize practical value in every guide.
+- Test commands, links, and examples before committing.
+- Follow existing documentation structure instead of creating new sections
+  unnecessarily.
+- Emphasize how AI improves existing workflows rather than replacing curators.

--- a/ai.just
+++ b/ai.just
@@ -1,12 +1,15 @@
+claude:
+  [ -f CLAUDE.md ] || ln -s AGENTS.md CLAUDE.md
+
 goosehints:
-  [ -f .goosehints ] || ln -s CLAUDE.md .goosehints
+  [ -f .goosehints ] || ln -s AGENTS.md .goosehints
 
 copilot-instructions:
-  [ -f .github/copilot-instructions.md ] || cd .github && ln -s ../CLAUDE.md copilot-instructions.md
+  [ -f .github/copilot-instructions.md ] || cd .github && ln -s ../AGENTS.md copilot-instructions.md
 
 setup-ai: setup-ai-instructions setup-gh
 
-setup-ai-instructions: goosehints copilot-instructions
+setup-ai-instructions: claude goosehints copilot-instructions
 
 setup-gh: gh-add-topics gh-add-secrets
 
@@ -14,9 +17,33 @@ gh-add-topics:
   gh repo edit --add-topic "monarchinitiative,ai4curation"
 
 gh-add-secrets:
-  gh secret set PAT_FOR_PR --body "$PAT_FOR_PR"
-  gh secret set ANTHROPIC_API_KEY --body "$ANTHROPIC_API_KEY"
-  gh secret set OPENAI_API_KEY --body "$OPENAI_API_KEY"
-  gh secret set CBORG_API_KEY --body "$CBORG_API_KEY"
-  gh secret set CLAUDE_CODE_OATH_TOKEN --body "$CLAUDE_CODE_OATH_TOKEN"
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  # Function to set secret if env var exists
+  set_secret_if_exists() {
+    local secret_name="$1"
+    local gh_var="GH_$secret_name"
+    local plain_var="$secret_name"
+
+    if [ -n "${!gh_var:-}" ]; then
+      echo "Setting $secret_name from $gh_var"
+      gh secret set "$secret_name" --body "${!gh_var}"
+    elif [ -n "${!plain_var:-}" ]; then
+      echo "Setting $secret_name from $plain_var"
+      gh secret set "$secret_name" --body "${!plain_var}"
+    else
+      echo "Skipping $secret_name (neither $gh_var nor $plain_var is set)"
+    fi
+  }
+
+  # Set each secret if the corresponding env var exists
+  set_secret_if_exists "PAT_FOR_PR"
+  set_secret_if_exists "ANTHROPIC_API_KEY"
+  set_secret_if_exists "OPENAI_API_KEY"
+  set_secret_if_exists "CBORG_API_KEY"
+  set_secret_if_exists "CLAUDE_CODE_OAUTH_TOKEN"
+
+gh-invite-dragon-ai:
+  gh api repos/:owner/:repo/collaborators/dragon-ai-agent --method PUT --field permission=write > /dev/null
 


### PR DESCRIPTION
## Summary

- add a repo-level `AGENTS.md` with practical guidance for AI coding agents
- add `.goosehints` and `.github/copilot-instructions.md` symlinks to the shared instructions
- update `ai.just` setup recipes to target `AGENTS.md`, skip unset secrets, and use the correctly spelled `CLAUDE_CODE_OAUTH_TOKEN`
- add a helper recipe for inviting the Dragon AI agent collaborator

## Validation

- `git diff --cached --check`
- `just --list -f ai.just` in a clean worktree
- verified committed symlink targets in a clean worktree