### PR TITLE
[codex] Add curator training materials

### DIFF
--- a/docs/reference/claude-skills.md
+++ b/docs/reference/claude-skills.md
@@ -60,7 +60,7 @@ These skills are particularly valuable for:
 
 1. Choose your installation method above
 2. Explore the [full documentation](https://github.com/ai4curation/curation-skills) for detailed usage examples
-3. Review related guides in the [how-tos section](../how-tos/index.md) for integration strategies
+3. Review related guides such as [Integrate AI into your KB](../how-tos/integrate-ai-into-your-kb.md) for integration strategies
 
 ## Resources
 

--- a/docs/reference/clients/codex-cli.md
+++ b/docs/reference/clients/codex-cli.md
@@ -4,7 +4,7 @@ url: https://github.com/openai/codex
 logo: https://openai.com/favicon.ico
 models: OpenAI GPT-4, Claude, and others
 ui_type: CLI
-ease_of_use_for_non_technical: 3
+ease_of_use_for_non_technical: 2
 github: https://github.com/openai/codex
 ---
 

--- a/docs/reference/clients/gemini-cli.md
+++ b/docs/reference/clients/gemini-cli.md
@@ -4,7 +4,7 @@ url: https://github.com/google-gemini/gemini-cli
 logo: https://www.gstatic.com/ai/web/favicons/favicon-32x32.png
 models: Gemini 2.5 Pro, Vertex AI models
 ui_type: CLI
-ease_of_use_for_non_technical: 4
+ease_of_use_for_non_technical: 2
 github: https://github.com/google-gemini/gemini-cli
 ---
 

--- a/docs/reference/clients/goose.md
+++ b/docs/reference/clients/goose.md
@@ -4,7 +4,9 @@ url: https://block.github.io/goose/
 logo: https://block.github.io/goose/img/logo_light.png
 models: Any
 ui_type: Desktop or CLI
-ease_of_use_for_non_technical: 5
+ease_of_use_for_non_technical: 4
+power_rating: 3
+notes: "Good ease-of-use for non-technical users but less powerful than Claude Code for complex agentic tasks"
 github: https://github.com/block/goose
 ---
 

--- a/docs/tutorials/tutorials-for-curators.md
+++ b/docs/tutorials/tutorials-for-curators.md
@@ -1,0 +1,32 @@
+# Training Materials for Curators
+
+This page collects video tutorials and training materials for curators learning to use AI tools.
+
+## OBO Academy AI Training
+
+The [OBO Academy Monarch Ontology Training](https://oboacademy.github.io/obook/courses/monarch-obo-training/) offers regular seminars on ontology development and AI-assisted curation workflows. Key AI-focused sessions include:
+
+### Claude Code for Biocuration
+
+- **Efficient Biocuration and Bioinformatics with Claude Code Part 1** (October 2025) - Chris Tabone
+  Practical introduction to using Claude Code for biocuration tasks.
+
+- **Using AI Coding Apps for Ontology Developers** (June 2025) - Chris Mungall
+  Overview of agentic AI tools for ontology development, focusing on Goose and Claude Code.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/4nyeGFACPKI" title="Using AI Coding Apps for Ontology Development - OBO Academy Seminar by Chris Mungall" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+### Earlier AI Sessions
+
+- **Introduction to developing agentic workflows for semantic engineers** (April 2025) - Chris Mungall
+- **AI-assisted ontology editing workflows 2: Validation** (April 2024) - Chris Mungall
+- **AI-assisted ontology editing workflows 1: Generating and Augmenting** (March 2024) - Chris Mungall
+- **Enhancing curation workflows with CurateGPT** (November 2023) - Chris Mungall
+
+See the full [OBO Academy training calendar](https://oboacademy.github.io/obook/courses/monarch-obo-training/) for all sessions.
+
+## External Resources
+
+- [OBO Academy obook](https://oboacademy.github.io/obook/) - Comprehensive semantic engineering training materials
+- [Claude Code tutorial for ontology developers](https://oboacademy.github.io/obook/tutorial/claude-code-getting-started/) - Step-by-step guide for getting started
+- [DeepLearning.AI Claude Code course](https://learn.deeplearning.ai/courses/claude-code-a-highly-agentic-coding-assistant/) - General introduction accessible to non-programmers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
      - Create an agentic curation pipeline: how-tos/create-agentic-curation-pipeline.md
      - PR reviews for agent improvement: how-tos/pr-reviews-for-agent-improvement.md
   - Tutorials:
+     - Training materials for curators: tutorials/tutorials-for-curators.md
      - Ontology editing with AI: tutorials/ontology-editing-with-ai.md
   - Reference:
      - Client apps: reference/client-apps.md


### PR DESCRIPTION
## Summary

- add a curator training materials tutorial page with OBO Academy and external resources
- add the new tutorial to the MkDocs navigation
- recalibrate client metadata for CLI ease-of-use and add a Goose power note
- fix an existing broken `how-tos` link in the Claude skills reference

## Validation

- `git diff --cached --check`
- `uv run mkdocs build --strict` in a clean worktree