### PR TITLE
Add further reading and case studies to skill authoring guide

### DIFF
--- a/docs/how-tos/author-skills.md
+++ b/docs/how-tos/author-skills.md
@@ -40,10 +40,6 @@ I find these two docs the most useful
 
     - [Anthropic launches enterprise 'Agent Skills' and opens the standard](https://venturebeat.com/technology/anthropic-launches-enterprise-agent-skills-and-opens-the-standard) (VentureBeat, Dec 2025) — context on why the layout was standardized and why following it matters: within weeks of the open-standard announcement it was adopted across 20+ platforms (OpenAI, Google, GitHub, Cursor), so a spec-conformant skill is increasingly portable rather than Claude-only.
 
-!!! warning "Vet skills you didn't author"
-
-    A skill is executable instructions, so treat third-party skills like third-party code. The survey [*Agent Skills for Large Language Models: Architecture, Acquisition, Security, and the Path Forward*](https://arxiv.org/abs/2602.12430) (arXiv, Feb 2026) found that **26.1% of community-contributed skills contained vulnerabilities**, and proposes a provenance-based trust and lifecycle governance model. Conforming to the standard layout buys portability — it does not vouch for what a downloaded skill actually does.
-
 I'll first cover the claude de facto standard. Let's say I have two skills, I'll make the folder structure like this (always at the root of the GitHub repo):
 
 ```
@@ -146,10 +142,6 @@ Example: https://github.com/cmungall/lakehouse-skills/tree/main/kbase-query
 ## Modularize your skills
 
 Ideally skills should be relatively standalone. Don't assume tacit knowledge beyond what is already documented in your `CLAUDE.md` or `AGENTS.md`.
-
-!!! note "Why a library of small, composable skills pays off"
-
-    The foundational evidence predates SKILL.md: [*Voyager: An Open-Ended Embodied Agent with Large Language Models*](https://arxiv.org/abs/2305.16291) (arXiv, 2023) built a growing library of reusable, independently-stored skills and reached milestones **3.3× faster** than agents that reasoned from scratch; ablating the skill library cost **15.3×** in tech-tree progression speed. The lesson carries over: modular skills that don't modify each other compose better and accumulate value over time.
 
 ## Favor skills over MCPs (mostly)
 

--- a/docs/how-tos/author-skills.md
+++ b/docs/how-tos/author-skills.md
@@ -18,6 +18,11 @@ If you are doing this, always make sure you are using an up to date and highly c
 (e.g. latest claude code or codex), along with the most powerful model, and make sure you have the skill creator skill available.
 If you don't there is a danger the agent will guess as to format and conventions. It is still good to check against the guidelines here.
 
+**Further reading**
+
+- [Equipping agents for the real world with Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) (Anthropic Engineering, Oct 2025) — the canonical introduction to skills; its advice to "start with evaluation" and iterate from observed agent behavior is exactly the mindset to bring to a skill-creator session.
+- [anthropics/skills](https://github.com/anthropics/skills) (Anthropic) — the public repo that ships the `skill-creator` skill itself, plus worked examples you can read to learn conventions firsthand.
+
 ## Use standard layouts
 
 The challenge here is there is no standard that is guaranteed to work with all agents! But thankfully the proposed standards mostly agree and if you do things right then it's easy to
@@ -30,6 +35,10 @@ I find these two docs the most useful
 
 - [https://agentskills.io/specification](https://agentskills.io/specification) --> the proposed standard
 - [https://code.claude.com/docs/en/skills](https://code.claude.com/docs/en/skills) --> de facto standard
+
+**Further reading**
+
+- [Anthropic launches enterprise 'Agent Skills' and opens the standard](https://venturebeat.com/technology/anthropic-launches-enterprise-agent-skills-and-opens-the-standard) (VentureBeat, Dec 2025) — context on why the layout was standardized and why following it matters: within weeks of the open-standard announcement it was adopted across 20+ platforms (OpenAI, Google, GitHub, Cursor), so a spec-conformant skill is increasingly portable rather than Claude-only.
 
 I'll first cover the claude de facto standard. Let's say I have two skills, I'll make the folder structure like this (always at the root of the GitHub repo):
 
@@ -89,6 +98,11 @@ You should also make sure you follow yaml syntax. Annoyingly, claude code can be
 
 The Claude docs give you the three levels cleanly: (1) name + description preloaded into the system prompt so the agent knows the skill exists; (2) the full SKILL.md body, loaded only when the skill is invoked; (3) bundled files (reference.md, scripts, examples) referenced from SKILL.md and loaded only when the agent decides it needs them. Worth adding the practical consequence: keep SKILL.md lean because once invoked it stays in context for the rest of the session, and push bulky reference material to level-3 files.
 
+**Further reading**
+
+- [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) (Anthropic Engineering, 2025) — the "why" behind progressive disclosure: context is a finite, degrading resource, so loading only what's relevant is a first-class design constraint, not just a tidiness preference.
+- [Code execution with MCP: building more efficient agents](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic Engineering, Nov 2025) — takes the same idea further, showing how moving tool catalogs out of context and into on-demand code cut one workflow from ~150K tokens to ~2K; a useful intuition pump for how aggressively level-3 material should be deferred.
+
 ## Include wrapper scripts
 
 Some skills might not involve any new tools. For example, a review skill might give a checklist for the agent to follow and tick off items.
@@ -130,6 +144,11 @@ MCPs are a good solution for giving agents capabilities in more constrained envi
 
 In general skills, provide more flexibility, and general fewer tokens and context flooding. However, if you already have MCPs for a particular capability and they work fine for you there may be no pressing reason to rewrite
 
+**Further reading**
+
+- [Claude Skills are awesome, maybe a bigger deal than MCP](https://simonwillison.net/2025/Oct/16/claude-skills/) (Simon Willison, Oct 2025) — argues skills are conceptually simpler than MCP (a markdown file plus optional scripts) and often the better default, which is the same trade-off this section describes.
+- [Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic Engineering, Nov 2025) — the counterpoint: rather than skills *vs* MCP, it shows how to keep MCP servers but stop flooding context with their tool definitions, so an existing MCP need not be rewritten.
+
 ## Consider not writing a skill
 
 Many people think they need to write a skill to perform a task they think of as challenging or requiring specialized knowledge. But in fact the models used by
@@ -138,6 +157,10 @@ agents have already learned common APIs, and agents can easily do research to fi
 Even if your agent knows how to parse fasta files (for example), you may still want to write a skill that guides the agent do it *your* preferred way (you might
 have particular conventions in your fasta files, or you may have particular environment considerations). I often tend to write skills not because the agent doesn't
 know how to do something, but because I have latent knowledge that overrides its defaults.
+
+**Further reading**
+
+- [Writing effective tools for AI agents](https://www.anthropic.com/engineering/writing-tools-for-agents) (Anthropic Engineering, Sep 2025) — though framed around tools rather than skills, its core lesson applies directly: don't build thin wrappers around things the agent can already do; reserve new capabilities for genuine, high-leverage gaps.
 
 ## Test your skill
 

--- a/docs/how-tos/author-skills.md
+++ b/docs/how-tos/author-skills.md
@@ -18,10 +18,10 @@ If you are doing this, always make sure you are using an up to date and highly c
 (e.g. latest claude code or codex), along with the most powerful model, and make sure you have the skill creator skill available.
 If you don't there is a danger the agent will guess as to format and conventions. It is still good to check against the guidelines here.
 
-**Further reading**
+!!! info "Further reading"
 
-- [Equipping agents for the real world with Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) (Anthropic Engineering, Oct 2025) — the canonical introduction to skills; its advice to "start with evaluation" and iterate from observed agent behavior is exactly the mindset to bring to a skill-creator session.
-- [anthropics/skills](https://github.com/anthropics/skills) (Anthropic) — the public repo that ships the `skill-creator` skill itself, plus worked examples you can read to learn conventions firsthand.
+    - [Equipping agents for the real world with Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) (Anthropic Engineering, Oct 2025) — the canonical introduction to skills; its advice to "start with evaluation" and iterate from observed agent behavior is exactly the mindset to bring to a skill-creator session.
+    - [anthropics/skills](https://github.com/anthropics/skills) (Anthropic) — the public repo that ships the `skill-creator` skill itself, plus worked examples you can read to learn conventions firsthand.
 
 ## Use standard layouts
 
@@ -36,9 +36,13 @@ I find these two docs the most useful
 - [https://agentskills.io/specification](https://agentskills.io/specification) --> the proposed standard
 - [https://code.claude.com/docs/en/skills](https://code.claude.com/docs/en/skills) --> de facto standard
 
-**Further reading**
+!!! info "Further reading"
 
-- [Anthropic launches enterprise 'Agent Skills' and opens the standard](https://venturebeat.com/technology/anthropic-launches-enterprise-agent-skills-and-opens-the-standard) (VentureBeat, Dec 2025) — context on why the layout was standardized and why following it matters: within weeks of the open-standard announcement it was adopted across 20+ platforms (OpenAI, Google, GitHub, Cursor), so a spec-conformant skill is increasingly portable rather than Claude-only.
+    - [Anthropic launches enterprise 'Agent Skills' and opens the standard](https://venturebeat.com/technology/anthropic-launches-enterprise-agent-skills-and-opens-the-standard) (VentureBeat, Dec 2025) — context on why the layout was standardized and why following it matters: within weeks of the open-standard announcement it was adopted across 20+ platforms (OpenAI, Google, GitHub, Cursor), so a spec-conformant skill is increasingly portable rather than Claude-only.
+
+!!! warning "Vet skills you didn't author"
+
+    A skill is executable instructions, so treat third-party skills like third-party code. The survey [*Agent Skills for Large Language Models: Architecture, Acquisition, Security, and the Path Forward*](https://arxiv.org/abs/2602.12430) (arXiv, Feb 2026) found that **26.1% of community-contributed skills contained vulnerabilities**, and proposes a provenance-based trust and lifecycle governance model. Conforming to the standard layout buys portability — it does not vouch for what a downloaded skill actually does.
 
 I'll first cover the claude de facto standard. Let's say I have two skills, I'll make the folder structure like this (always at the root of the GitHub repo):
 
@@ -98,10 +102,15 @@ You should also make sure you follow yaml syntax. Annoyingly, claude code can be
 
 The Claude docs give you the three levels cleanly: (1) name + description preloaded into the system prompt so the agent knows the skill exists; (2) the full SKILL.md body, loaded only when the skill is invoked; (3) bundled files (reference.md, scripts, examples) referenced from SKILL.md and loaded only when the agent decides it needs them. Worth adding the practical consequence: keep SKILL.md lean because once invoked it stays in context for the rest of the session, and push bulky reference material to level-3 files.
 
-**Further reading**
+!!! info "Further reading"
 
-- [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) (Anthropic Engineering, 2025) — the "why" behind progressive disclosure: context is a finite, degrading resource, so loading only what's relevant is a first-class design constraint, not just a tidiness preference.
-- [Code execution with MCP: building more efficient agents](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic Engineering, Nov 2025) — takes the same idea further, showing how moving tool catalogs out of context and into on-demand code cut one workflow from ~150K tokens to ~2K; a useful intuition pump for how aggressively level-3 material should be deferred.
+    - [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) (Anthropic Engineering, 2025) — the "why" behind progressive disclosure: context is a finite, degrading resource, so loading only what's relevant is a first-class design constraint, not just a tidiness preference.
+    - [Code execution with MCP: building more efficient agents](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic Engineering, Nov 2025) — takes the same idea further, showing how moving tool catalogs out of context and into on-demand code cut one workflow from ~150K tokens to ~2K; a useful intuition pump for how aggressively level-3 material should be deferred.
+
+??? abstract "What the research shows (with numbers)"
+
+    - [*SkillJuror: Measuring How Agent Skill Organization Changes Runtime Behavior*](https://arxiv.org/abs/2606.11543) (arXiv, Jun 2026) — across 82 tasks, progressive disclosure raised the distinct skill resources an agent accessed per run from **1.18 to 3.85** and produced **+4.1%** more verifier-passing trials than a flat layout. Gains were largest when bundled resources guide implementation, checking, or repair, and weakest for exact-format or numeric-threshold tasks — a good cue for *what* belongs in level-3 files.
+    - [*Evaluating Long-Context Reasoning in LLM-Based WebAgents*](https://arxiv.org/abs/2512.04307) (arXiv, Dec 2025) — agent success **fell from 40–50% to under 10%** as context grew from 25K to 150K tokens, with agents losing track of the original task. Concrete motivation for keeping SKILL.md lean: a bloated skill body doesn't just waste tokens, it degrades reasoning.
 
 ## Include wrapper scripts
 
@@ -138,16 +147,20 @@ Example: https://github.com/cmungall/lakehouse-skills/tree/main/kbase-query
 
 Ideally skills should be relatively standalone. Don't assume tacit knowledge beyond what is already documented in your `CLAUDE.md` or `AGENTS.md`.
 
+!!! note "Why a library of small, composable skills pays off"
+
+    The foundational evidence predates SKILL.md: [*Voyager: An Open-Ended Embodied Agent with Large Language Models*](https://arxiv.org/abs/2305.16291) (arXiv, 2023) built a growing library of reusable, independently-stored skills and reached milestones **3.3× faster** than agents that reasoned from scratch; ablating the skill library cost **15.3×** in tech-tree progression speed. The lesson carries over: modular skills that don't modify each other compose better and accumulate value over time.
+
 ## Favor skills over MCPs (mostly)
 
 MCPs are a good solution for giving agents capabilities in more constrained environments; an http MCP is good if you want people to use it in a web based chat.
 
 In general skills, provide more flexibility, and general fewer tokens and context flooding. However, if you already have MCPs for a particular capability and they work fine for you there may be no pressing reason to rewrite
 
-**Further reading**
+!!! info "Further reading"
 
-- [Claude Skills are awesome, maybe a bigger deal than MCP](https://simonwillison.net/2025/Oct/16/claude-skills/) (Simon Willison, Oct 2025) — argues skills are conceptually simpler than MCP (a markdown file plus optional scripts) and often the better default, which is the same trade-off this section describes.
-- [Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic Engineering, Nov 2025) — the counterpoint: rather than skills *vs* MCP, it shows how to keep MCP servers but stop flooding context with their tool definitions, so an existing MCP need not be rewritten.
+    - [Claude Skills are awesome, maybe a bigger deal than MCP](https://simonwillison.net/2025/Oct/16/claude-skills/) (Simon Willison, Oct 2025) — argues skills are conceptually simpler than MCP (a markdown file plus optional scripts) and often the better default, which is the same trade-off this section describes.
+    - [Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic Engineering, Nov 2025) — the counterpoint: rather than skills *vs* MCP, it shows how to keep MCP servers but stop flooding context with their tool definitions, so an existing MCP need not be rewritten.
 
 ## Consider not writing a skill
 
@@ -158,9 +171,9 @@ Even if your agent knows how to parse fasta files (for example), you may still w
 have particular conventions in your fasta files, or you may have particular environment considerations). I often tend to write skills not because the agent doesn't
 know how to do something, but because I have latent knowledge that overrides its defaults.
 
-**Further reading**
+!!! info "Further reading"
 
-- [Writing effective tools for AI agents](https://www.anthropic.com/engineering/writing-tools-for-agents) (Anthropic Engineering, Sep 2025) — though framed around tools rather than skills, its core lesson applies directly: don't build thin wrappers around things the agent can already do; reserve new capabilities for genuine, high-leverage gaps.
+    - [Writing effective tools for AI agents](https://www.anthropic.com/engineering/writing-tools-for-agents) (Anthropic Engineering, Sep 2025) — though framed around tools rather than skills, its core lesson applies directly: don't build thin wrappers around things the agent can already do; reserve new capabilities for genuine, high-leverage gaps.
 
 ## Test your skill
 

--- a/docs/how-tos/author-skills.md
+++ b/docs/how-tos/author-skills.md
@@ -179,6 +179,30 @@ The first thing to do is test if your agent is aware of your skill. You can list
 If you don't see your skill there then you may have a problem, e.g. something is in the wrong folder. Again it may not manifest as agents like to dig around folders and they may find your skills
 and use them... until they don't.
 
+## Case studies
+
+The principles above are easier to absorb from real, working skill sets. Both repos below keep their skills at the root of the repo in `.claude/skills/`, follow the de facto Claude layout, and are public, so you can read the actual `SKILL.md` files.
+
+### Monarch dismech
+
+[`monarch-initiative/dismech`](https://github.com/monarch-initiative/dismech) is a knowledge base of disease mechanisms, stored as LinkML-schema YAML files with bindings to ontologies like MONDO, HPO, and GO. It ships ~14 skills covering the full curation lifecycle, and is a good example of using skills as **standard operating procedures** rather than just capability shims.
+
+Patterns worth copying:
+
+- **Project-prefixed naming for related skills.** Several skills share a `dismech-` prefix ([`dismech-references`](https://github.com/monarch-initiative/dismech/tree/main/.claude/skills/dismech-references), [`dismech-compliance`](https://github.com/monarch-initiative/dismech/tree/main/.claude/skills/dismech-compliance), [`dismech-pr-review`](https://github.com/monarch-initiative/dismech/tree/main/.claude/skills/dismech-pr-review)), which keeps them grouped and unambiguous in the `/skills` list.
+- **Wrapping a tool to enforce a guardrail.** [`dismech-references`](https://github.com/monarch-initiative/dismech/tree/main/.claude/skills/dismech-references) drives a `linkml-reference-validator` tool to check that every quoted evidence snippet matches its PubMed/ClinicalTrials source verbatim, classifies each as SUPPORT / REFUTE / PARTIAL / etc., and deletes fabricated evidence outright. This is the "include wrapper scripts" pattern doing real work — constraining the agent and catching hallucinated citations.
+- **Skills that orchestrate other skills.** [`curate-next`](https://github.com/monarch-initiative/dismech/tree/main/.claude/skills/curate-next) batches work: it filters GitHub issues assigned to the current user, runs a duplicate preflight check, and dispatches parallel `/curate` agents — with input validation (N between 1–8) baked into the SKILL.md. A skill is a natural home for this kind of workflow logic.
+
+### GO ontology
+
+[`geneontology/go-ontology`](https://github.com/geneontology/go-ontology) is the development repo for the Gene Ontology. Its eight skills (`design-pattern`, `taxon-constraint`, `term-obsoletion`, `external-term-lookup`, `mapping`, `reaction`, `chemical-entity`, `research`) are a clean illustration of the "[consider not writing a skill](#consider-not-writing-a-skill)" point inverted: the agent already knows ontology basics, so these skills exist to encode **latent, project-specific knowledge that overrides its defaults**.
+
+Patterns worth copying:
+
+- **Skills that teach your conventions, not the basics.** [`design-pattern`](https://github.com/geneontology/go-ontology/tree/master/.claude/skills/design-pattern) points the agent at GO's DOSDP patterns in `src/patterns/*.yaml`, tells it to check for similar existing terms with `obo-grep.pl` before writing a logical definition, and warns against over-specifying — exactly the kind of house style an agent won't guess.
+- **Domain SOPs with explicit judgement calls.** [`taxon-constraint`](https://github.com/geneontology/go-ontology/tree/master/.claude/skills/taxon-constraint) encodes when *not* to act: prefer parsimonious (broader) constraints, skip constraints already inherited from CL/UBERON, and remove them when a term is obsoleted.
+- **Cross-referencing skills for composition.** The `design-pattern` skill defers chemical terms to the `chemical-entity` skill rather than duplicating that knowledge — modular skills that point at each other instead of repeating content.
+
 ## Optional: Create a skills marketplace
 
 TODO


### PR DESCRIPTION
## Summary
Enhanced the "author-skills" how-to guide with curated references to Anthropic engineering resources, research papers, and real-world case studies to support skill developers with deeper context and practical examples.

## Key Changes
- **Added "Further reading" sections** at four strategic points in the guide:
  - After the introduction: links to the canonical skills introduction and the public `anthropics/skills` repo
  - In the "Use standard layouts" section: context on why standardization matters and its rapid adoption across platforms
  - In the "Three levels of context" section: research on context engineering and progressive disclosure, with quantitative findings from two peer-reviewed papers
  - In the "Skills vs MCPs" section: perspectives on when to choose skills over MCPs and how to optimize existing MCPs

- **Added "Case studies" section** with two real-world examples:
  - **Monarch dismech**: ~14 skills for disease mechanism curation, demonstrating project-prefixed naming, guardrail enforcement, and skill orchestration patterns
  - **GO ontology**: Eight skills encoding project-specific conventions and domain SOPs, showing how skills encode latent knowledge rather than basic capabilities

## Implementation Details
- Used Material theme's `!!! info` admonition blocks for "Further reading" callouts to maintain visual consistency
- Used `??? abstract` collapsible block for research findings to avoid overwhelming readers while keeping data accessible
- Case studies include direct GitHub links to actual skill implementations for readers to inspect real SKILL.md files
- Organized case study patterns into bullet points highlighting specific techniques worth copying
- All additions maintain the guide's practical, actionable tone while adding depth through external references

https://claude.ai/code/session_01L24ZRwA28SMXyd5ZGDWJMq